### PR TITLE
Add Premain EA link, Premain JEP links, link to training run doc

### DIFF
--- a/site/_index.md
+++ b/site/_index.md
@@ -19,12 +19,15 @@ href="/groups/core-libs/">Core Libraries</a> Groups. </p>
 Design notes
 ------------
 
+  - [Thoughts on Training Runs](https://openjdk.org/projects/leyden/notes/05-training-runs) (2024/9)
+  - The "Premain" JEPs: [JEP 483: AOT Class Loading & Linking](https://openjdk.org/jeps/483) (2024/8),<br/>
+    [JEP draft: Ahead-of-Time Code Compilation](https://openjdk.org/jeps/8335368)<br/>
+    [JEP draft: Ahead-of-Time Method Profiling](https://openjdk.org/jeps/8325147)
   - [Condensing Indy Bootstraps](notes/04-condensing-bootstraps) (2023/8)
   - [Toward Condensers](notes/03-toward-condensers) (2023/7)
   - [Selectively Shifting and Constraining
     Computation](notes/02-shift-and-constrain) (2022/10)
   - [Project Leyden: Beginnings](notes/01-beginnings) (2022/5)
-
 
 Presentations
 -------------
@@ -52,3 +55,5 @@ Resources
   - Mailing list: [leyden-dev](https://mail.openjdk.org/mailman/listinfo/leyden-dev)
     (you must subscribe to the list in order to post to it)
   - Repository: [openjdk/leyden](https://github.com/openjdk/leyden)
+  - Early access builds: <https://jdk.java.net/leyden/> (including "Premain" work)
+


### PR DESCRIPTION
Some adds to the index page:

 - premain JEP and EA links
 - link to Dan's doc about training runs

One thing that baffled me a bit is the `<br/>` elements in the markdown.  These seem to be either hand-inserted as an attempt to do line length control, or else they are artifacts of an old cut-and-paste. Do we really want them?  If so, can we put in a comment in the markdown that says how to maintain them, please?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Dan Heidinga](https://openjdk.org/census#heidinga) (@DanHeidinga - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/leyden-docs.git pull/4/head:pull/4` \
`$ git checkout pull/4`

Update a local copy of the PR: \
`$ git checkout pull/4` \
`$ git pull https://git.openjdk.org/leyden-docs.git pull/4/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 4`

View PR using the GUI difftool: \
`$ git pr show -t 4`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/leyden-docs/pull/4.diff">https://git.openjdk.org/leyden-docs/pull/4.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/leyden-docs/pull/4#issuecomment-2354385276)